### PR TITLE
Separate Spoofax instance per project

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ dependencies {
 }
 ```
 
+### Parallel Builds
+
+If you have a multi-project build, then you might be able to build projects that do not directly depend upon each other in parallel.
+To enable parallel task execution, use the `--parallel` flag or add the following to the project's `gradle.properties`:
+
+```
+org.gradle.parallel=true
+```
+
 ### Language Testing
 
 Assume you have a project `foo.lang` that defines the language and contains one or more .spt files.

--- a/src/main/java/nl/martijndwars/spoofax/SpoofaxPlugin.java
+++ b/src/main/java/nl/martijndwars/spoofax/SpoofaxPlugin.java
@@ -232,7 +232,7 @@ public class SpoofaxPlugin implements Plugin<Project> {
     SpoofaxPluginExtension spoofaxPluginExtension = getExtension(project);
     List<String> overrides = spoofaxPluginExtension.getOverrides().get();
 
-    GradleSpoofaxProjectConfigService projectConfigService = (GradleSpoofaxProjectConfigService) spoofax.injector.getInstance(IProjectConfigService.class);
+    GradleSpoofaxProjectConfigService projectConfigService = (GradleSpoofaxProjectConfigService) getSpoofax(project).injector.getInstance(IProjectConfigService.class);
     projectConfigService.setOverrides(overrides);
 
     for (Object override : overrides) {
@@ -332,10 +332,10 @@ public class SpoofaxPlugin implements Plugin<Project> {
 
   public static synchronized void loadLanguage(Project project, File file) throws MetaborgException {
     project.getLogger().info("Loading language component from: " + file);
-    FileObject archiveFile = spoofax.resourceService.resolve(file);
+    FileObject archiveFile = getSpoofax(project).resourceService.resolve(file);
 
     try {
-      ILanguageImpl languageImpl = loadLanguage(archiveFile);
+      ILanguageImpl languageImpl = loadLanguage(project, archiveFile);
 
       for (ILanguageComponent languageComponent : languageImpl.components()) {
         project.getLogger().info("Loaded {}", languageComponent);
@@ -345,11 +345,11 @@ public class SpoofaxPlugin implements Plugin<Project> {
     }
   }
 
-  protected static ILanguageImpl loadLanguage(FileObject archiveFile) throws FileSystemException, MetaborgException {
+  protected static ILanguageImpl loadLanguage(Project project, FileObject archiveFile) throws FileSystemException, MetaborgException {
     if (archiveFile.isFile()) {
-      return spoofax.languageDiscoveryService.languageFromArchive(archiveFile);
+      return getSpoofax(project).languageDiscoveryService.languageFromArchive(archiveFile);
     } else {
-      return spoofax.languageDiscoveryService.languageFromDirectory(archiveFile);
+      return getSpoofax(project).languageDiscoveryService.languageFromDirectory(archiveFile);
     }
   }
 }

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageArchive.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageArchive.java
@@ -11,8 +11,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.metaborg.core.MetaborgException;
 import org.metaborg.spoofax.meta.core.build.LanguageSpecBuildInput;
 
-import static nl.martijndwars.spoofax.SpoofaxInit.overridenBuildInput;
-import static nl.martijndwars.spoofax.SpoofaxInit.spoofaxMeta;
+import static nl.martijndwars.spoofax.SpoofaxInit.*;
 
 public class LanguageArchive extends AbstractTask {
   protected final RegularFileProperty outputFile;
@@ -53,7 +52,7 @@ public class LanguageArchive extends AbstractTask {
 
     LanguageSpecBuildInput input = overridenBuildInput(getProject(), strategoFormat, languageVersion, overrides);
 
-    spoofaxMeta.metaBuilder.pkg(input);
-    spoofaxMeta.metaBuilder.archive(input);
+    getSpoofaxMeta(getProject()).metaBuilder.pkg(input);
+    getSpoofaxMeta(getProject()).metaBuilder.archive(input);
   }
 }

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageCheck.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageCheck.java
@@ -73,7 +73,7 @@ public class LanguageCheck extends AbstractTask {
       return;
     }
 
-    ILanguageImpl languageImpl = spoofax.languageService.getImpl(languageUnderTestIdentifier);
+    ILanguageImpl languageImpl = getSpoofax(getProject()).languageService.getImpl(languageUnderTestIdentifier);
 
     if (languageImpl == null) {
       getLogger().info("Skipping tests because language under test was not found.");
@@ -82,11 +82,11 @@ public class LanguageCheck extends AbstractTask {
 
     getLogger().info("Running SPT tests");
     IProject project = overridenLanguageSpec(getProject(), strategoFormat, languageVersion, overrides);
-    sptInjector.getInstance(SPTRunner.class).test(project, sptLanguageImpl, languageImpl);
+    getSptInjector(getProject()).getInstance(SPTRunner.class).test(project, sptLanguageImpl, languageImpl);
   }
 
   protected ILanguageImpl getSptLanguageImpl() {
-    Iterable<? extends ILanguageImpl> sptLangs = spoofax.languageService.getAllImpls(GROUP_ID, LANG_SPT_ID);
+    Iterable<? extends ILanguageImpl> sptLangs = getSpoofax(getProject()).languageService.getAllImpls(GROUP_ID, LANG_SPT_ID);
 
     final int sptLangsSize = Iterables.size(sptLangs);
 

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageClean.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageClean.java
@@ -17,9 +17,9 @@ public class LanguageClean extends AbstractTask {
 
     CleanInput input = new CleanInputBuilder(spoofaxProject(getProject()))
       .withSelector(new SpoofaxIgnoresSelector())
-      .build(spoofax.dependencyService);
+      .build(getSpoofax(getProject()).dependencyService);
 
-    spoofax.processorRunner.clean(input, null, null).schedule().block();
-    spoofaxMeta.metaBuilder.clean(buildInput(getProject()));
+    getSpoofax(getProject()).processorRunner.clean(input, null, null).schedule().block();
+    getSpoofaxMeta(getProject()).metaBuilder.clean(buildInput(getProject()));
   }
 }

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageCompile.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageCompile.java
@@ -58,22 +58,21 @@ public class LanguageCompile extends AbstractTask {
 
     getLogger().info("Generating Spoofax sources");
 
-    spoofaxMeta.metaBuilder.initialize(input);
-    spoofaxMeta.metaBuilder.generateSources(input, null);
+    getSpoofaxMeta(getProject()).metaBuilder.initialize(input);
+    getSpoofaxMeta(getProject()).metaBuilder.generateSources(input, null);
 
     final BuildInputBuilder inputBuilder = new BuildInputBuilder(languageSpec);
     final BuildInput buildInput = inputBuilder
       .withDefaultIncludePaths(true)
       .withSourcesFromDefaultSourceLocations(true)
       .withSelector(new SpoofaxIgnoresSelector())
-      .withMessagePrinter(new StreamMessagePrinter(spoofax.sourceTextService, true, true, logger))
+      .withMessagePrinter(new StreamMessagePrinter(getSpoofax(getProject()).sourceTextService, true, true, logger))
       .withThrowOnErrors(true)
       .withPardonedLanguageStrings(languageSpec.config().pardonedLanguages())
       .addTransformGoal(new CompileGoal())
-      .build(spoofax.dependencyService, spoofax.languagePathService);
+      .build(getSpoofax(getProject()).dependencyService, getSpoofax(getProject()).languagePathService);
 
-    spoofax.processorRunner.build(buildInput, null, null).schedule().block();
-
-    spoofaxMeta.metaBuilder.compile(input);
+    getSpoofax(getProject()).processorRunner.build(buildInput, null, null).schedule().block();
+    getSpoofaxMeta(getProject()).metaBuilder.compile(input);
   }
 }


### PR DESCRIPTION
Previously, when building in parallel, different tasks could interfere because they used the same Spoofax instance. This PR makes sure that a separate Spoofax instance is created for every project, allowing safe parallel builds.