### PR TITLE
Have Travis use trusty instead of xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Oracle JDK8 is only supported on trusty (instead of the default, xenial)
+dist: trusty
 language: java
 jdk:
   - openjdk8


### PR DESCRIPTION
Because Xenial does not support Oracle Java 8: https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/3.