### PR TITLE
Maintenance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'signing'
-    id 'com.gradle.plugin-publish' version '0.10.0'
+    id 'com.gradle.plugin-publish'
 }
 
 group 'nl.martijndwars'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 metaborgVersion=2.5.4
 junitVersion=5.3.2
+gradlePluginPublishVersion=0.10.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,7 @@
-rootProject.name = 'spoofax-gradle-plugin'
+pluginManagement {
+    plugins {
+        id 'com.gradle.plugin-publish' version gradlePluginPublishVersion
+    }
+}
 
+rootProject.name = 'spoofax-gradle-plugin'

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageArchive.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageArchive.java
@@ -10,6 +10,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.metaborg.core.MetaborgException;
@@ -76,6 +77,7 @@ public class LanguageArchive extends AbstractTask {
     return outputFile;
   }
 
+  @Internal
   public Provider<File> getLazyOutputFile() {
     LanguageSpecBuildInput buildInput = overridenBuildInput(getProject(), strategoFormat, languageVersion, overrides);
     LanguageIdentifier identifier = buildInput.languageSpec().config().identifier();

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageCheck.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageCheck.java
@@ -6,6 +6,7 @@ import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.metaborg.core.MetaborgException;
@@ -85,6 +86,7 @@ public class LanguageCheck extends AbstractTask {
     getSptInjector(getProject()).getInstance(SPTRunner.class).test(project, sptLanguageImpl, languageImpl);
   }
 
+  @Internal
   protected ILanguageImpl getSptLanguageImpl() {
     Iterable<? extends ILanguageImpl> sptLangs = getSpoofax(getProject()).languageService.getAllImpls(GROUP_ID, LANG_SPT_ID);
 
@@ -101,6 +103,7 @@ public class LanguageCheck extends AbstractTask {
     return Iterables.get(sptLangs, 0);
   }
 
+  @Internal
   protected LanguageIdentifier getLanguageUnderTestIdentifier() {
     if (languageUnderTest.isPresent()) {
       return LanguageIdentifier.parseFull(languageUnderTest.get());

--- a/src/main/java/nl/martijndwars/spoofax/tasks/LanguageSpx.java
+++ b/src/main/java/nl/martijndwars/spoofax/tasks/LanguageSpx.java
@@ -6,6 +6,7 @@ import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 
@@ -58,6 +59,7 @@ public class LanguageSpx extends AbstractArchiveTask {
     return overrides;
   }
 
+  @Internal
   public RegularFileProperty getInputFile() {
     return inputFile;
   }


### PR DESCRIPTION
* Move version of Gradle plugin to properties.gradle, have the pluginManagement block use this property to configure the version (possible since Gradle 5.6).
* Mark internal properties with `@Internal` to avoid warnings from the `:validateTaskProperties` task when building the plugin.